### PR TITLE
Test::LWP::UserAgent Update

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+          - Clearing network_fallback from %options before calling parent's
+          constructor.
 
 0.010     2012-10-06 16:47:33 PDT-0700 (Karen Etheridge)
           - documentation on integration with XML::Compile::SOAP

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Test::LWP::UserAgent - a LWP::UserAgent suitable for simulating and testing netw
 
 # VERSION
 
-version 0.010
+version 0.011
 
 # SYNOPSIS
 

--- a/lib/Test/LWP/UserAgent.pm
+++ b/lib/Test/LWP/UserAgent.pm
@@ -24,11 +24,13 @@ sub new
 {
     my ($class, %options) = @_;
 
+    my $_network_fallback = delete $options{network_fallback}; # Not accepted by LWP::UserAgent;
+
     my $self = $class->SUPER::new(%options);
     $self->{__last_http_request_sent} = undef;
     $self->{__last_http_response_received} = undef;
     $self->{__response_map} = [];
-    $self->{__network_fallback} = $options{network_fallback};
+    $self->{__network_fallback} = $_network_fallback;
 
     # strips default User-Agent header added by LWP::UserAgent, to make it
     # easier to define literal HTTP::Requests to match against


### PR DESCRIPTION
Hey Karen,

After further investigation, it looks like the Test::LWP::UserAgent is passing in the params including the network_fallback to LWP::UserAgent, which croaks on unknown arguments when $^W is set. I can reproduce this on my unit tests by running them with perl -w, which triggers extra warnings.

Thanks,

Mike
