### PR TITLE
Chained method calls

### DIFF
--- a/lib/Test/LWP/UserAgent.pm
+++ b/lib/Test/LWP/UserAgent.pm
@@ -83,6 +83,7 @@ sub map_response
     {
         push @response_map, [ $request_description, $response ];
     }
+    return $self;
 }
 
 sub map_network_response
@@ -152,6 +153,7 @@ sub unregister_psgi
     {
         @response_map = grep { $_->[0] ne $domain } @response_map;
     }
+    return $self;
 }
 
 sub last_http_request_sent

--- a/lib/Test/LWP/UserAgent.pm
+++ b/lib/Test/LWP/UserAgent.pm
@@ -518,6 +518,8 @@ Instance mappings take priority over global (class method) mappings - if no
 matches are found from mappings added to the instance, the global mappings are
 then examined. When no matches have been found, a 404 response is returned.
 
+This method returns the C<Test::LWP::UserAgent> object.
+
 =head2 C<map_network_response($request_description)>
 
 Same as C<map_response> above, only requests that match this description will
@@ -563,6 +565,8 @@ a server so as to test your client code.
 You might find using L<Plack::Test> or L<Plack::Test::ExternalServer> easier
 for your needs, so check those out as well.
 
+This method returns the C<Test::LWP::UserAgent> object.
+
 =head2 C<unregister_psgi($domain, instance_only?)>
 
 When called as a class method, removes a domain->PSGI app entry that had been
@@ -578,6 +582,8 @@ If you want to mask a global registration on just one particular instance,
 then add C<undef> as a mapping on your instance:
 
     $useragent->map_response($domain, undef);
+
+This method returns the C<Test::LWP::UserAgent> object.
 
 =head2 C<last_http_request_sent>
 

--- a/t/12-chained-method-call.t
+++ b/t/12-chained-method-call.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings FATAL => 'all';
+
+use Test::More;
+use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
+
+use HTTP::Message::PSGI ();
+use HTTP::Response ();
+use Test::LWP::UserAgent ();
+
+{
+    my $ua = Test::LWP::UserAgent->new->register_psgi( abc => sub {} );
+    isa_ok $ua, 'Test::LWP::UserAgent', 'register_psgi';
+}
+
+{
+    my $ua = Test::LWP::UserAgent->new->map_response(
+        abc => HTTP::Response->new(200),
+    );
+    isa_ok $ua, 'Test::LWP::UserAgent', 'map_response';
+}
+
+{
+    my $ua = Test::LWP::UserAgent->new->register_psgi( abc => sub {} )
+        ->unregister_psgi('abc');
+    isa_ok $ua, 'Test::LWP::UserAgent', 'unregister_psgi';
+}
+
+done_testing();


### PR DESCRIPTION
Instead of writing
```
my $ua = Test::LWP::UserAgent->new;
$ua->method(...);
```
I wanted to write
```
my $ua = Test::LWP::UserAgent->new->method(...);
```

These patches let me call chained method handlers.