### PR TITLE
Extend request match with Test::Deep and HTTP::Common

### DIFF
--- a/lib/Test/LWP/UserAgent.pm
+++ b/lib/Test/LWP/UserAgent.pm
@@ -203,6 +203,9 @@ sub _match_request
 		return freeze($request) eq freeze($request_desc);
 	}
 
+	return !! $request_desc->matching ($request)
+		if $request_desc->$_isa('HTTP::Config');
+
 	return Test::Deep::eq_deeply ($request, $request_desc)
 		if $request_desc->$_isa('Test::Deep::Cmp');
 
@@ -532,6 +535,16 @@ returns a boolean indicating if there is a match.
 
 The L<HTTP::Request> object is matched identically (including all query
 parameters, headers etc) against the provided object.
+
+=item * L<HTTP::Config> object
+
+    use HTTP::Config;
+	my $config = HTTP::Config->new;
+	$config->add (m_method => 'GET', m_secure => 0);
+
+	$test_ua->map_response ($config => HTTP::Response->new ('400'));
+
+See L<HTTP::Config> for details how to match request.
 
 =item * L<Test::Deep> comparison
 

--- a/lib/Test/LWP/UserAgent.pm
+++ b/lib/Test/LWP/UserAgent.pm
@@ -203,6 +203,9 @@ sub _match_request
 		return freeze($request) eq freeze($request_desc);
 	}
 
+	return Test::Deep::eq_deeply ($request, $request_desc)
+		if $request_desc->$_isa('Test::Deep::Cmp');
+
 	return $uri =~ $request_desc
 		if __is_regexp($request_desc);
 
@@ -529,6 +532,20 @@ returns a boolean indicating if there is a match.
 
 The L<HTTP::Request> object is matched identically (including all query
 parameters, headers etc) against the provided object.
+
+=item * L<Test::Deep> comparison
+
+Applies L<Test::Deep>'s C<eq_deeply> on request to detect match.
+It's up to caller to make it available.
+
+    use Test::Deep;
+	# matches any GET requests with query parameter bar=baz
+    my $match = methods (
+	    method => 'GET',
+		uri => methods ([query_param => 'bar'] => 'baz'),
+	),
+
+	$test_ua->map_response ($match => HTTP::Response->new('200'));
 
 =back
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -6,6 +6,8 @@ use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
 use Test::Deep 0.110;
 use Scalar::Util 'refaddr';
 
+use HTTP::Config;
+
 # simulates real code that we are testing
 {
     package MyApp;
@@ -163,6 +165,21 @@ cmp_deeply(
     test_send_request(
         'Test::Deep comparison / foo', 'HEAD', 'http://foo', '3000', 'fail', { a => 1 },
             str('http://foo:3000/fail'), 'a=1', '200',  # globally, returning 500
+    );
+
+    $MyApp::useragent->unmap_all;
+
+	my $config = HTTP::Config->new;
+	$config->add (m_method => 'HEAD', _uri => qr/foo/);
+
+	$MyApp::useragent->map_response(
+		$config,
+		HTTP::Response->new ('201'),
+	);
+
+    test_send_request(
+        'HTTP::Config comparison / foo', 'HEAD', 'http://foo', '3000', 'fail', { a => 1 },
+            str('http://foo:3000/fail'), 'a=1', '201',  # globally, returning 500
     );
 
     $MyApp::useragent->unmap_all;

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -154,6 +154,19 @@ cmp_deeply(
         'all mappings are now gone', 'GET', 'http://foo', '3000', 'success', { a => 1 },
             str('http://foo:3000/success?a=1'), '', '404',
     );
+
+	$MyApp::useragent->map_response(
+		methods(method => 'HEAD', uri => re (qr/foo/)),
+		HTTP::Response->new ('200'),
+	);
+
+    test_send_request(
+        'Test::Deep comparison / foo', 'HEAD', 'http://foo', '3000', 'fail', { a => 1 },
+            str('http://foo:3000/fail'), 'a=1', '200',  # globally, returning 500
+    );
+
+    $MyApp::useragent->unmap_all;
+
 }
 
 sub test_send_request


### PR DESCRIPTION
To allow users to write their tests using matching pattern they are familiar with (as well as save few noisy tokens of source code) as well as spread knowledge of these existing modules.

`Test::Deep` is already used by `Test::LWP::UserAgent`'s tests.
`HTTP::Config` is part of `HTTP-Message`